### PR TITLE
take all scrollheight in canvas instead of offsetheight, fixed sudden jumps

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -14144,6 +14144,7 @@ angular.module('znk.infra.znkChat').run(['$templateCache', function($templateCac
                         
                         var onHoverCb = function () {
                             if (currQuestion) {
+                                drawer.stopDrawing();
                                 eventsManager.killMouseEvents();
 
                                 canvasDomElement = canvasOfElement;
@@ -14160,8 +14161,21 @@ angular.module('znk.infra.znkChat').run(['$templateCache', function($templateCac
 
                     function _setCanvasDimensions(canvasDomContainerElement, elementToCoverDomElement) {
                         toolBoxCtrl.isExerciseReady().then(function () {
-                            canvasDomContainerElement[0].setAttribute('height', elementToCoverDomElement.offsetHeight);
-                            canvasDomContainerElement[0].setAttribute('width', elementToCoverDomElement.offsetWidth);
+                            var height,width;
+                            if (elementToCoverDomElement.scrollHeight) {
+                                height = elementToCoverDomElement.scrollHeight;
+                            }
+                            else {
+                                height = elementToCoverDomElement.offsetHeight;
+                            }
+                            if (elementToCoverDomElement.scrollWidth) {
+                                width = elementToCoverDomElement.scrollWidth;
+                            }
+                            else {
+                                width = elementToCoverDomElement.offsetWidth;
+                            }
+                            canvasDomContainerElement[0].setAttribute('height', height);
+                            canvasDomContainerElement[0].setAttribute('width', width);
                             canvasDomContainerElement.css('position', 'absolute');
                         });
 

--- a/dist/znkExercise/znkExercise.js
+++ b/dist/znkExercise/znkExercise.js
@@ -2932,6 +2932,7 @@
                         
                         var onHoverCb = function () {
                             if (currQuestion) {
+                                drawer.stopDrawing();
                                 eventsManager.killMouseEvents();
 
                                 canvasDomElement = canvasOfElement;
@@ -2948,8 +2949,21 @@
 
                     function _setCanvasDimensions(canvasDomContainerElement, elementToCoverDomElement) {
                         toolBoxCtrl.isExerciseReady().then(function () {
-                            canvasDomContainerElement[0].setAttribute('height', elementToCoverDomElement.offsetHeight);
-                            canvasDomContainerElement[0].setAttribute('width', elementToCoverDomElement.offsetWidth);
+                            var height,width;
+                            if (elementToCoverDomElement.scrollHeight) {
+                                height = elementToCoverDomElement.scrollHeight;
+                            }
+                            else {
+                                height = elementToCoverDomElement.offsetHeight;
+                            }
+                            if (elementToCoverDomElement.scrollWidth) {
+                                width = elementToCoverDomElement.scrollWidth;
+                            }
+                            else {
+                                width = elementToCoverDomElement.offsetWidth;
+                            }
+                            canvasDomContainerElement[0].setAttribute('height', height);
+                            canvasDomContainerElement[0].setAttribute('width', width);
                             canvasDomContainerElement.css('position', 'absolute');
                         });
 

--- a/src/components/znkExercise/toolbox/tools/draw/znkExerciseDrawTool.directive.js
+++ b/src/components/znkExercise/toolbox/tools/draw/znkExerciseDrawTool.directive.js
@@ -510,6 +510,7 @@
                         
                         var onHoverCb = function () {
                             if (currQuestion) {
+                                drawer.stopDrawing();
                                 eventsManager.killMouseEvents();
 
                                 canvasDomElement = canvasOfElement;
@@ -526,8 +527,21 @@
 
                     function _setCanvasDimensions(canvasDomContainerElement, elementToCoverDomElement) {
                         toolBoxCtrl.isExerciseReady().then(function () {
-                            canvasDomContainerElement[0].setAttribute('height', elementToCoverDomElement.offsetHeight);
-                            canvasDomContainerElement[0].setAttribute('width', elementToCoverDomElement.offsetWidth);
+                            var height,width;
+                            if (elementToCoverDomElement.scrollHeight) {
+                                height = elementToCoverDomElement.scrollHeight;
+                            }
+                            else {
+                                height = elementToCoverDomElement.offsetHeight;
+                            }
+                            if (elementToCoverDomElement.scrollWidth) {
+                                width = elementToCoverDomElement.scrollWidth;
+                            }
+                            else {
+                                width = elementToCoverDomElement.offsetWidth;
+                            }
+                            canvasDomContainerElement[0].setAttribute('height', height);
+                            canvasDomContainerElement[0].setAttribute('width', width);
                             canvasDomContainerElement.css('position', 'absolute');
                         });
 


### PR DESCRIPTION
draw.stopDrawing() should fix the "sudden jumps" bug when drawing on the screen

setting height to be scrollHeight instead of offsetHeight should fix the "dead areas" that can't be drawn on